### PR TITLE
UDP Integration with HAProxy Enterprise 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,34 @@ kubectl apply -f sample-workload.yaml
 # http://HAPROXY-FLOATING-IP (Floating HA IP)
 ```
 
+#### Configure UDP LoadBalancer
+```bash
+# Apply the UDP sample workload:
+kubectl apply -f udp-sample-workload.yml
+
+# Get the NodePort and Node IP for your UDP service:
+kubectl get svc udp-service -o jsonpath='{.spec.ports[0].nodePort}'
+kubectl get nodes -o wide
+
+# Modify the aux.cfg file to add UDP servers using the NodePort and define the Frontend IP:Port:
+server udpserver NODE_IP:NODE_PORT
+
+# Apply the sample workload
+kubectl apply -f sample-workload.yaml
+
+# SSH into your HAPEE machines
+
+# Copy the modified aux.cfg file to the instance(s) in the following path /etc/hapee-3.0/
+
+# Restart the HAPEE Kubernetes ingress service
+sudo systemctl restart hapee-3.0-kubernetes-ingress
+
+#Test the UDP connection:
+echo "hello" | nc -u IP PORT
+
+```
+
+
 **Note**: Ensure your AWS CLI is configured with the correct region and credentials.
 
 ### High Availability Setup Instructions

--- a/aux.cfg
+++ b/aux.cfg
@@ -1,0 +1,10 @@
+global
+  module-load hapee-lb-udp.so
+udp-lb udp-dns
+  dgram-bind X.X.X.X:XX
+
+
+  balance roundrobin
+  option udp-check
+
+  server udpserver X.X.X.X:XX

--- a/outputs.tf
+++ b/outputs.tf
@@ -76,3 +76,33 @@ output "configure_kubectl" {
        ${var.ha == "yes" ? "http://${aws_eip.ha_floating_ip[0].carrier_ip} (Floating HA IP)" : "http://${aws_eip.tf-wavelength-ip["primary"].carrier_ip}"}
   EOT
 }
+output "udp_hapee_instructions" {
+  description = "Instructions for setting up UDP in HAPEE External Ingress controller"
+  value       = <<-EOT    
+    To configure UDP support in your HAPEE External Ingress controller:
+    
+    1. Apply the UDP sample workload:
+       kubectl apply -f udp-sample-workload.yml
+    
+    2. Get the NodePort and Node IP for your UDP service:
+       kubectl get svc udp-service -o jsonpath='{.spec.ports[0].nodePort}'
+       kubectl get nodes -o wide
+    
+    3. Modify the aux.cfg file to add UDP servers using the NodePort:
+       server udpserver NODE_IP:NODE_PORT
+       
+       Replace NODE_IP with your node's IP address and NODE_PORT with the NodePort number.
+       
+    4. SSH into your HAPEE machines
+    
+    5. Copy the modified aux.cfg file to the instance(s) in the following path /etc/hapee-3.0/
+    
+    6. Restart the HAPEE Kubernetes ingress service:
+       sudo systemctl restart hapee-3.0-kubernetes-ingress
+    
+    7. Test the UDP connection:
+       echo "hello" | nc -u localhost 9090
+    
+    8. Important: Remember to modify your security groups to allow UDP traffic on the required ports
+  EOT
+}

--- a/udp-sample-workload.yml
+++ b/udp-sample-workload.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: udp-echo
+  template:
+    metadata:
+      labels:
+        app: udp-echo
+    spec:
+      containers:
+      - name: udp-echo
+        image: alpine
+        command: ["/bin/sh"]
+        args:
+        - "-c"
+        - "apk add --no-cache socat && socat -v UDP-LISTEN:8000,fork EXEC:'/bin/cat'"
+        ports:
+        - containerPort: 8000
+          protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-echo
+spec:
+  selector:
+    app: udp-echo
+  ports:
+  - name: udp
+    port: 8000
+    protocol: UDP
+    targetPort: 8000
+  type: NodePort 


### PR DESCRIPTION
Request to include UDP Integration when using HAProxy Enterprise
Changes:
- Updating the readme
- Adding aux.cfg that contains haproxy configuration
- Adding udp deployment/service
- Modifying output to share the steps to use UDP
